### PR TITLE
:sparkles: feat : 대기열 토큰 발급 API 구현

### DIFF
--- a/src/main/kotlin/org/example/concertbackend/api/queue/WaitingQueueApi.kt
+++ b/src/main/kotlin/org/example/concertbackend/api/queue/WaitingQueueApi.kt
@@ -1,0 +1,22 @@
+package org.example.concertbackend.api.queue
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.example.concertbackend.api.queue.request.RegisterQueueRequest
+import org.example.concertbackend.api.queue.response.RegisterQueueResponse
+import org.example.concertbackend.common.model.ApiResponse
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+
+@Tag(name = "대기열 API", description = "대기열 등록 및 상태를 확인하기 위한 API 입니다.")
+interface WaitingQueueApi {
+    @Operation(
+        summary = "대기열 등록",
+        description = "대기열에 등록하고 토큰을 반환합니다.",
+    )
+    @PostMapping
+    fun addToQueue(
+        @RequestBody request: RegisterQueueRequest,
+    ): ResponseEntity<ApiResponse<RegisterQueueResponse>>
+}

--- a/src/main/kotlin/org/example/concertbackend/api/queue/WaitingQueueController.kt
+++ b/src/main/kotlin/org/example/concertbackend/api/queue/WaitingQueueController.kt
@@ -3,33 +3,29 @@ package org.example.concertbackend.api.queue
 import org.example.concertbackend.api.queue.request.RegisterQueueRequest
 import org.example.concertbackend.api.queue.response.RegisterQueueResponse
 import org.example.concertbackend.api.queue.response.TokenPositionQueueResponse
+import org.example.concertbackend.application.queue.usecase.WaitingQueueUseCase
 import org.example.concertbackend.common.model.ApiResponse
 import org.example.concertbackend.common.model.SuccessType
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
-import java.util.*
 
 @RestController
-@RequestMapping("/v1/queue")
-class QueueController {
-    @PostMapping("/tokens")
-    fun addToQueue(
+@RequestMapping("/v1/waiting-queue")
+class WaitingQueueController(
+    private val waitingQueueUseCase: WaitingQueueUseCase,
+) : WaitingQueueApi {
+    override fun addToQueue(
         @RequestBody request: RegisterQueueRequest,
     ): ResponseEntity<ApiResponse<RegisterQueueResponse>> =
         ResponseEntity.status(HttpStatus.CREATED).body(
             ApiResponse.success(
                 SuccessType.QUEUE_REGISTERED,
-                RegisterQueueResponse(
-                    token = UUID.randomUUID().toString(),
-                    status = "WAITING",
-                    waitingNumber = 1,
-                ),
+                waitingQueueUseCase.addToQueue(request),
             ),
         )
 

--- a/src/main/kotlin/org/example/concertbackend/api/queue/request/RegisterQueueRequest.kt
+++ b/src/main/kotlin/org/example/concertbackend/api/queue/request/RegisterQueueRequest.kt
@@ -1,5 +1,15 @@
 package org.example.concertbackend.api.queue.request
 
+import io.swagger.v3.oas.annotations.media.Schema
+import org.example.concertbackend.common.exception.BusinessException
+import org.example.concertbackend.common.model.ErrorType
+
+@Schema(description = "대기열 등록 요청")
 data class RegisterQueueRequest(
-    val userId: Long
-)
+    @Schema(description = "사용자 ID", example = "1")
+    val userId: Long,
+) {
+    init {
+        require(userId > 0) { throw BusinessException(ErrorType.USER_NOT_FOUND) }
+    }
+}

--- a/src/main/kotlin/org/example/concertbackend/api/queue/response/RegisterQueueResponse.kt
+++ b/src/main/kotlin/org/example/concertbackend/api/queue/response/RegisterQueueResponse.kt
@@ -2,6 +2,4 @@ package org.example.concertbackend.api.queue.response
 
 data class RegisterQueueResponse(
     val token: String,
-    val status: String,
-    val waitingNumber: Int
 )

--- a/src/main/kotlin/org/example/concertbackend/application/queue/service/QueueTokenCommandService.kt
+++ b/src/main/kotlin/org/example/concertbackend/application/queue/service/QueueTokenCommandService.kt
@@ -1,0 +1,23 @@
+package org.example.concertbackend.application.queue.service
+
+import org.example.concertbackend.common.util.IdGenerator
+import org.example.concertbackend.domain.queue.QueueToken
+import org.example.concertbackend.domain.queue.QueueTokenRepository
+import org.springframework.stereotype.Service
+
+@Service
+class QueueTokenCommandService(
+    private val idGenerator: IdGenerator,
+    private val queueTokenRepository: QueueTokenRepository,
+) {
+    fun create(userId: Long): QueueToken {
+        val token = idGenerator.generate()
+        val queueToken =
+            QueueToken(
+                token = token,
+                userId = userId,
+            )
+
+        return queueTokenRepository.save(queueToken)
+    }
+}

--- a/src/main/kotlin/org/example/concertbackend/application/queue/service/QueueTokenQueryService.kt
+++ b/src/main/kotlin/org/example/concertbackend/application/queue/service/QueueTokenQueryService.kt
@@ -1,0 +1,11 @@
+package org.example.concertbackend.application.queue.service
+
+import org.example.concertbackend.domain.queue.QueueTokenRepository
+import org.springframework.stereotype.Service
+
+@Service
+class QueueTokenQueryService(
+    private val queueTokenRepository: QueueTokenRepository,
+) {
+    fun findByUserIdOrNull(userId: Long) = queueTokenRepository.findByUserIdOrNull(userId)
+}

--- a/src/main/kotlin/org/example/concertbackend/application/queue/service/WaitingQueueCommandService.kt
+++ b/src/main/kotlin/org/example/concertbackend/application/queue/service/WaitingQueueCommandService.kt
@@ -1,0 +1,15 @@
+package org.example.concertbackend.application.queue.service
+
+import org.example.concertbackend.domain.queue.WaitingQueue
+import org.example.concertbackend.domain.queue.WaitingQueueManager
+import org.springframework.stereotype.Service
+
+@Service
+class WaitingQueueCommandService(
+    private val waitingQueueManager: WaitingQueueManager,
+) {
+    fun addToQueue(queueToken: String): WaitingQueue {
+        val queueInToken = WaitingQueue(queueToken)
+        return waitingQueueManager.addToQueue(queueInToken)
+    }
+}

--- a/src/main/kotlin/org/example/concertbackend/application/queue/usecase/WaitingQueueUseCase.kt
+++ b/src/main/kotlin/org/example/concertbackend/application/queue/usecase/WaitingQueueUseCase.kt
@@ -1,0 +1,28 @@
+package org.example.concertbackend.application.queue.usecase
+
+import org.example.concertbackend.api.queue.request.RegisterQueueRequest
+import org.example.concertbackend.api.queue.response.RegisterQueueResponse
+import org.example.concertbackend.application.queue.service.QueueTokenCommandService
+import org.example.concertbackend.application.queue.service.QueueTokenQueryService
+import org.example.concertbackend.application.queue.service.WaitingQueueCommandService
+import org.example.concertbackend.application.user.service.UserQueryService
+import org.springframework.stereotype.Component
+
+@Component
+class WaitingQueueUseCase(
+    private val userQueryService: UserQueryService,
+    private val waitingQueueCommandService: WaitingQueueCommandService,
+    private val queueTokenCommandService: QueueTokenCommandService,
+    private val queueTokenQueryService: QueueTokenQueryService,
+) {
+    fun addToQueue(request: RegisterQueueRequest): RegisterQueueResponse {
+        userQueryService.findById(request.userId)
+        val waitingQueueInToken =
+            queueTokenQueryService.findByUserIdOrNull(request.userId)
+                ?: queueTokenCommandService
+                    .create(request.userId)
+                    .also { waitingQueueCommandService.addToQueue(it.token) }
+
+        return RegisterQueueResponse(waitingQueueInToken.token)
+    }
+}

--- a/src/main/kotlin/org/example/concertbackend/application/user/service/UserQueryService.kt
+++ b/src/main/kotlin/org/example/concertbackend/application/user/service/UserQueryService.kt
@@ -1,0 +1,16 @@
+package org.example.concertbackend.application.user.service
+
+import org.example.concertbackend.common.exception.BusinessException
+import org.example.concertbackend.common.model.ErrorType
+import org.example.concertbackend.domain.user.User
+import org.example.concertbackend.domain.user.UserRepository
+import org.springframework.stereotype.Service
+
+@Service
+class UserQueryService(
+    private val userRepository: UserRepository,
+) {
+    fun findById(id: Long): User =
+        userRepository.findByIdOrNull(id)
+            ?: throw BusinessException(ErrorType.USER_NOT_FOUND)
+}

--- a/src/main/kotlin/org/example/concertbackend/common/util/IdGenerator.kt
+++ b/src/main/kotlin/org/example/concertbackend/common/util/IdGenerator.kt
@@ -1,0 +1,5 @@
+package org.example.concertbackend.common.util
+
+interface IdGenerator {
+    fun generate(): String
+}

--- a/src/main/kotlin/org/example/concertbackend/common/util/UuidGenerator.kt
+++ b/src/main/kotlin/org/example/concertbackend/common/util/UuidGenerator.kt
@@ -1,0 +1,9 @@
+package org.example.concertbackend.common.util
+
+import org.springframework.stereotype.Component
+import java.util.*
+
+@Component
+class UuidGenerator : IdGenerator {
+    override fun generate(): String = UUID.randomUUID().toString()
+}

--- a/src/main/kotlin/org/example/concertbackend/domain/queue/QueueTokenRepository.kt
+++ b/src/main/kotlin/org/example/concertbackend/domain/queue/QueueTokenRepository.kt
@@ -1,0 +1,7 @@
+package org.example.concertbackend.domain.queue
+
+interface QueueTokenRepository {
+    fun save(queueToken: QueueToken): QueueToken
+
+    fun findByUserIdOrNull(userId: Long): QueueToken?
+}

--- a/src/main/kotlin/org/example/concertbackend/domain/queue/WaitingQueueManager.kt
+++ b/src/main/kotlin/org/example/concertbackend/domain/queue/WaitingQueueManager.kt
@@ -1,0 +1,7 @@
+package org.example.concertbackend.domain.queue
+
+interface WaitingQueueManager {
+    fun addToQueue(queue: WaitingQueue): WaitingQueue
+
+    fun findPosition(queueToken: String): Int
+}

--- a/src/main/kotlin/org/example/concertbackend/domain/user/UserRepository.kt
+++ b/src/main/kotlin/org/example/concertbackend/domain/user/UserRepository.kt
@@ -1,0 +1,5 @@
+package org.example.concertbackend.domain.user
+
+interface UserRepository {
+    fun findByIdOrNull(id: Long): User?
+}

--- a/src/main/kotlin/org/example/concertbackend/infrastructure/persistence/queue/mapper/QueueTokenJpaMapper.kt
+++ b/src/main/kotlin/org/example/concertbackend/infrastructure/persistence/queue/mapper/QueueTokenJpaMapper.kt
@@ -1,0 +1,20 @@
+package org.example.concertbackend.infrastructure.persistence.queue.mapper
+
+import org.example.concertbackend.domain.queue.QueueToken
+import org.example.concertbackend.infrastructure.persistence.queue.entity.QueueTokenJpaEntity
+
+fun QueueToken.toJpaEntity(): QueueTokenJpaEntity =
+    QueueTokenJpaEntity(
+        userId = userId,
+        token = token,
+        expiresAt = expiresAt,
+        id = id,
+    )
+
+fun QueueTokenJpaEntity.toDomain(): QueueToken =
+    QueueToken(
+        userId = userId,
+        token = token,
+        expiresAt = expiresAt,
+        id = id,
+    )

--- a/src/main/kotlin/org/example/concertbackend/infrastructure/persistence/queue/mapper/WaitingQueueJpaMapper.kt
+++ b/src/main/kotlin/org/example/concertbackend/infrastructure/persistence/queue/mapper/WaitingQueueJpaMapper.kt
@@ -1,0 +1,18 @@
+package org.example.concertbackend.infrastructure.persistence.queue.mapper
+
+import org.example.concertbackend.domain.queue.WaitingQueue
+import org.example.concertbackend.infrastructure.persistence.queue.entity.WaitingQueueJpaEntity
+
+fun WaitingQueue.toJpaEntity(): WaitingQueueJpaEntity =
+    WaitingQueueJpaEntity(
+        id = id,
+        token = token,
+        status = status,
+    )
+
+fun WaitingQueueJpaEntity.toDomain(): WaitingQueue =
+    WaitingQueue(
+        id = id,
+        token = token,
+        status = status,
+    )

--- a/src/main/kotlin/org/example/concertbackend/infrastructure/persistence/queue/repository/DataJpaQueueTokenRepository.kt
+++ b/src/main/kotlin/org/example/concertbackend/infrastructure/persistence/queue/repository/DataJpaQueueTokenRepository.kt
@@ -1,0 +1,8 @@
+package org.example.concertbackend.infrastructure.persistence.queue.repository
+
+import org.example.concertbackend.infrastructure.persistence.queue.entity.QueueTokenJpaEntity
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface DataJpaQueueTokenRepository : JpaRepository<QueueTokenJpaEntity, Long> {
+    fun findByUserId(userId: Long): QueueTokenJpaEntity?
+}

--- a/src/main/kotlin/org/example/concertbackend/infrastructure/persistence/queue/repository/DataJpaWaitingQueueRepository.kt
+++ b/src/main/kotlin/org/example/concertbackend/infrastructure/persistence/queue/repository/DataJpaWaitingQueueRepository.kt
@@ -1,0 +1,18 @@
+package org.example.concertbackend.infrastructure.persistence.queue.repository
+
+import org.example.concertbackend.domain.queue.QueueStatus
+import org.example.concertbackend.infrastructure.persistence.queue.entity.WaitingQueueJpaEntity
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+
+interface DataJpaWaitingQueueRepository : JpaRepository<WaitingQueueJpaEntity, Long> {
+    @Query(
+        """
+            SELECT wq
+            FROM WaitingQueueJpaEntity wq 
+            WHERE wq.status = :status
+            ORDER BY wq.id ASC
+        """,
+    )
+    fun findAllByStatus(status: QueueStatus): List<WaitingQueueJpaEntity>
+}

--- a/src/main/kotlin/org/example/concertbackend/infrastructure/persistence/queue/repository/JpaQueueTokenRepository.kt
+++ b/src/main/kotlin/org/example/concertbackend/infrastructure/persistence/queue/repository/JpaQueueTokenRepository.kt
@@ -1,0 +1,23 @@
+package org.example.concertbackend.infrastructure.persistence.queue.repository
+
+import org.example.concertbackend.domain.queue.QueueToken
+import org.example.concertbackend.domain.queue.QueueTokenRepository
+import org.example.concertbackend.infrastructure.persistence.queue.mapper.toDomain
+import org.example.concertbackend.infrastructure.persistence.queue.mapper.toJpaEntity
+import org.springframework.stereotype.Repository
+
+@Repository
+class JpaQueueTokenRepository(
+    private val dataJpaQueueTokenRepository: DataJpaQueueTokenRepository,
+) : QueueTokenRepository {
+    override fun save(queueToken: QueueToken): QueueToken =
+        dataJpaQueueTokenRepository
+            .save(queueToken.toJpaEntity())
+            .toDomain()
+
+    override fun findByUserIdOrNull(userId: Long): QueueToken? {
+        return dataJpaQueueTokenRepository
+            .findByUserId(userId)
+            ?.toDomain()
+    }
+}

--- a/src/main/kotlin/org/example/concertbackend/infrastructure/persistence/queue/repository/JpaWaitingQueueRepository.kt
+++ b/src/main/kotlin/org/example/concertbackend/infrastructure/persistence/queue/repository/JpaWaitingQueueRepository.kt
@@ -1,0 +1,28 @@
+package org.example.concertbackend.infrastructure.persistence.queue.repository
+
+import org.example.concertbackend.common.exception.BusinessException
+import org.example.concertbackend.common.model.ErrorType
+import org.example.concertbackend.domain.queue.QueueStatus
+import org.example.concertbackend.domain.queue.WaitingQueue
+import org.example.concertbackend.domain.queue.WaitingQueueManager
+import org.example.concertbackend.infrastructure.persistence.queue.mapper.toDomain
+import org.example.concertbackend.infrastructure.persistence.queue.mapper.toJpaEntity
+import org.springframework.stereotype.Repository
+
+@Repository
+class JpaWaitingQueueRepository(
+    private val dataJpaWaitingQueueRepository: DataJpaWaitingQueueRepository,
+) : WaitingQueueManager {
+    override fun addToQueue(queue: WaitingQueue): WaitingQueue =
+        dataJpaWaitingQueueRepository
+            .save(queue.toJpaEntity())
+            .toDomain()
+
+    override fun findPosition(queueToken: String): Int =
+        dataJpaWaitingQueueRepository
+            .findAllByStatus(QueueStatus.WAITING)
+            .indexOfFirst { it.token == queueToken }
+            .takeIf { it >= 0 }
+            ?.inc()
+            ?: throw BusinessException(ErrorType.WAITING_QUEUE_TOKEN_NOT_FOUND)
+}

--- a/src/main/kotlin/org/example/concertbackend/infrastructure/persistence/user/entity/UserJpaEntity.kt
+++ b/src/main/kotlin/org/example/concertbackend/infrastructure/persistence/user/entity/UserJpaEntity.kt
@@ -1,0 +1,17 @@
+package org.example.concertbackend.infrastructure.persistence.user.entity
+
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.example.concertbackend.infrastructure.persistence.model.BaseTimeEntity
+
+@Entity
+@Table(name = "users")
+class UserJpaEntity(
+    val name: String,
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0,
+) : BaseTimeEntity()

--- a/src/main/kotlin/org/example/concertbackend/infrastructure/persistence/user/mapper/UserJpaMapper.kt
+++ b/src/main/kotlin/org/example/concertbackend/infrastructure/persistence/user/mapper/UserJpaMapper.kt
@@ -1,0 +1,10 @@
+package org.example.concertbackend.infrastructure.persistence.user.mapper
+
+import org.example.concertbackend.domain.user.User
+import org.example.concertbackend.infrastructure.persistence.user.entity.UserJpaEntity
+
+fun UserJpaEntity.toDomain(): User =
+    User(
+        id = id,
+        name = name,
+    )

--- a/src/main/kotlin/org/example/concertbackend/infrastructure/persistence/user/repository/DataJpaUserRepository.kt
+++ b/src/main/kotlin/org/example/concertbackend/infrastructure/persistence/user/repository/DataJpaUserRepository.kt
@@ -1,0 +1,6 @@
+package org.example.concertbackend.infrastructure.persistence.user.repository
+
+import org.example.concertbackend.infrastructure.persistence.user.entity.UserJpaEntity
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface DataJpaUserRepository : JpaRepository<UserJpaEntity, Long>

--- a/src/main/kotlin/org/example/concertbackend/infrastructure/persistence/user/repository/JpaUserRepository.kt
+++ b/src/main/kotlin/org/example/concertbackend/infrastructure/persistence/user/repository/JpaUserRepository.kt
@@ -1,0 +1,14 @@
+package org.example.concertbackend.infrastructure.persistence.user.repository
+
+import org.example.concertbackend.domain.user.User
+import org.example.concertbackend.domain.user.UserRepository
+import org.example.concertbackend.infrastructure.persistence.user.mapper.toDomain
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Repository
+
+@Repository
+class JpaUserRepository(
+    private val dataJpaUserRepository: DataJpaUserRepository,
+) : UserRepository {
+    override fun findByIdOrNull(id: Long): User? = dataJpaUserRepository.findByIdOrNull(id)?.toDomain()
+}

--- a/src/test/kotlin/org/example/concertbackend/api/queue/request/RegisterQueueRequestTest.kt
+++ b/src/test/kotlin/org/example/concertbackend/api/queue/request/RegisterQueueRequestTest.kt
@@ -1,0 +1,22 @@
+package org.example.concertbackend.api.queue.request
+
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.example.concertbackend.common.exception.BusinessException
+import org.example.concertbackend.common.model.ErrorType
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class RegisterQueueRequestTest {
+    @Nested
+    @DisplayName("객체 생성")
+    inner class Init {
+        @Test
+        @DisplayName("사용자 ID가 0 이하인 경우 예외를 던진다.")
+        fun initWhenUserIdIsZeroOrNegative() {
+            assertThatThrownBy { RegisterQueueRequest(0) }
+                .isInstanceOf(BusinessException::class.java)
+                .hasMessage(ErrorType.USER_NOT_FOUND.message)
+        }
+    }
+}

--- a/src/test/kotlin/org/example/concertbackend/application/queue/usecase/WaitingQueueUseCaseTest.kt
+++ b/src/test/kotlin/org/example/concertbackend/application/queue/usecase/WaitingQueueUseCaseTest.kt
@@ -1,0 +1,73 @@
+package org.example.concertbackend.application.queue.usecase
+
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.example.concertbackend.api.queue.request.RegisterQueueRequest
+import org.example.concertbackend.api.queue.response.RegisterQueueResponse
+import org.example.concertbackend.application.queue.service.QueueTokenCommandService
+import org.example.concertbackend.application.queue.service.QueueTokenQueryService
+import org.example.concertbackend.application.queue.service.WaitingQueueCommandService
+import org.example.concertbackend.application.user.service.UserQueryService
+import org.example.concertbackend.domain.queue.QueueToken
+import org.example.concertbackend.domain.queue.WaitingQueue
+import org.example.concertbackend.domain.user.User
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(MockKExtension::class)
+class WaitingQueueUseCaseTest {
+    @InjectMockKs
+    private lateinit var waitingQueueUseCase: WaitingQueueUseCase
+
+    @MockK
+    private lateinit var userQueryService: UserQueryService
+
+    @MockK
+    private lateinit var waitingQueueCommandService: WaitingQueueCommandService
+
+    @MockK
+    private lateinit var queueTokenCommandService: QueueTokenCommandService
+
+    @MockK
+    private lateinit var queueTokenQueryService: QueueTokenQueryService
+
+    @Nested
+    @DisplayName("대기열 큐 등록")
+    inner class AddToQueue {
+        private val token = "token"
+        private val request = RegisterQueueRequest(userId = 1)
+        private val user = User(id = request.userId, name = "test")
+        private val waitingQueueInToken = QueueToken(token = token, userId = request.userId)
+        private val want = RegisterQueueResponse(token)
+
+        @Test
+        @DisplayName("대기열에 이미 등록된 유저인 경우 대기열에 등록하지 않고 등록된 토큰을 반환한다.")
+        fun addToQueueWhenQueueTokenExists() {
+            every { userQueryService.findById(request.userId) } returns user
+            every { queueTokenQueryService.findByUserIdOrNull(request.userId) } returns waitingQueueInToken
+
+            val got = waitingQueueUseCase.addToQueue(request)
+
+            assertThat(got).isEqualTo(want)
+        }
+
+        @Test
+        @DisplayName("대기열에 등록되지 않은 유저의 경우 대기열 큐에 토큰 생성 후 등록하고 토큰을 반환한다.")
+        fun addToQueueWhenQueueTokenNotExists() {
+            val registerToken = WaitingQueue(token)
+            every { userQueryService.findById(request.userId) } returns user
+            every { queueTokenQueryService.findByUserIdOrNull(request.userId) } returns null
+            every { queueTokenCommandService.create(request.userId) } returns waitingQueueInToken
+            every { waitingQueueCommandService.addToQueue(token) } returns registerToken
+
+            val got = waitingQueueUseCase.addToQueue(request)
+
+            assertThat(got).isEqualTo(want)
+        }
+    }
+}

--- a/src/test/kotlin/org/example/concertbackend/application/user/service/UserQueryServiceTest.kt
+++ b/src/test/kotlin/org/example/concertbackend/application/user/service/UserQueryServiceTest.kt
@@ -1,0 +1,38 @@
+package org.example.concertbackend.application.user.service
+
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.example.concertbackend.common.exception.BusinessException
+import org.example.concertbackend.common.model.ErrorType
+import org.example.concertbackend.domain.user.UserRepository
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(MockKExtension::class)
+class UserQueryServiceTest {
+    @InjectMockKs
+    private lateinit var userQueryService: UserQueryService
+
+    @MockK
+    private lateinit var userRepository: UserRepository
+
+    @Nested
+    @DisplayName("id를 사용해서 유저 조회")
+    inner class FindById {
+        @Test
+        @DisplayName("유저가 존재하지 않는 경우 예외가 발생합니다.")
+        fun userNotExists() {
+            val userId = 1L
+            every { userRepository.findByIdOrNull(userId) } returns null
+
+            assertThatThrownBy { userQueryService.findById(userId) }
+                .isInstanceOf(BusinessException::class.java)
+                .hasMessage(ErrorType.USER_NOT_FOUND.message)
+        }
+    }
+}

--- a/src/test/kotlin/org/example/concertbackend/infrastructure/persistence/queue/repository/JpaWaitingQueueRepositoryTest.kt
+++ b/src/test/kotlin/org/example/concertbackend/infrastructure/persistence/queue/repository/JpaWaitingQueueRepositoryTest.kt
@@ -1,0 +1,59 @@
+package org.example.concertbackend.infrastructure.persistence.queue.repository
+
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.example.concertbackend.common.exception.BusinessException
+import org.example.concertbackend.common.model.ErrorType
+import org.example.concertbackend.domain.queue.QueueStatus
+import org.example.concertbackend.infrastructure.persistence.queue.entity.WaitingQueueJpaEntity
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.extension.ExtendWith
+import kotlin.test.Test
+
+@ExtendWith(MockKExtension::class)
+class JpaWaitingQueueRepositoryTest {
+    @InjectMockKs
+    private lateinit var jpaWaitingQueueRepository: JpaWaitingQueueRepository
+
+    @MockK
+    private lateinit var dataJpaWaitingQueueRepository: DataJpaWaitingQueueRepository
+
+    @Nested
+    @DisplayName("전달한 토큰의 현재 위치 조회")
+    inner class FindPosition {
+        private val token = "myToken"
+
+        private val data =
+            listOf(
+                WaitingQueueJpaEntity(token = token, status = QueueStatus.WAITING),
+                WaitingQueueJpaEntity(token = "test", status = QueueStatus.WAITING),
+            )
+
+        @Test
+        @DisplayName("토큰이 존재하는 경우 위치를 반환한다.")
+        fun tokenExists() {
+            val want = 1
+
+            every { dataJpaWaitingQueueRepository.findAllByStatus(QueueStatus.WAITING) } returns data
+
+            val got = jpaWaitingQueueRepository.findPosition(token)
+
+            assertThat(got).isEqualTo(want)
+        }
+
+        @Test
+        @DisplayName("토큰이 존재하지 않는 경우 예외를 발생시킵니다.")
+        fun tokenNotExists() {
+            every { dataJpaWaitingQueueRepository.findAllByStatus(QueueStatus.WAITING) } returns data
+
+            assertThatThrownBy { jpaWaitingQueueRepository.findPosition("notExists") }
+                .isInstanceOf(BusinessException::class.java)
+                .hasMessage(ErrorType.WAITING_QUEUE_TOKEN_NOT_FOUND.message)
+        }
+    }
+}


### PR DESCRIPTION
## 내용
- 대기열 토큰 발급을 위한 API 구현 
- 요청 객체와 API에 Swagger 설명 어노테이션 추가
- 랜덤 ID 제어를 위해 IDGenerator 인터페이스를 만들어 구현체를 쉽게 변경할 수 있도록 작성
- 같은 사용자라면 이전에 발급한 토큰을 전달하고, 다른 사용자라면 새롭게 토큰 발급 후 대기열에 등록하도록 구현