### PR TITLE
✨ feat : 대기열 토큰 조회 API 구현

### DIFF
--- a/src/main/kotlin/org/example/concertbackend/api/queue/WaitingQueueApi.kt
+++ b/src/main/kotlin/org/example/concertbackend/api/queue/WaitingQueueApi.kt
@@ -4,10 +4,13 @@ import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.example.concertbackend.api.queue.request.RegisterQueueRequest
 import org.example.concertbackend.api.queue.response.RegisterQueueResponse
+import org.example.concertbackend.api.queue.response.TokenPositionQueueResponse
 import org.example.concertbackend.common.model.ApiResponse
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestHeader
 
 @Tag(name = "대기열 API", description = "대기열 등록 및 상태를 확인하기 위한 API 입니다.")
 interface WaitingQueueApi {
@@ -19,4 +22,13 @@ interface WaitingQueueApi {
     fun addToQueue(
         @RequestBody request: RegisterQueueRequest,
     ): ResponseEntity<ApiResponse<RegisterQueueResponse>>
+
+    @Operation(
+        summary = "대기열 상태 조회",
+        description = "대기열에 대한 상태를 조회합니다.",
+    )
+    @GetMapping
+    fun findQueuePosition(
+        @RequestHeader("QUEUE-AUTH-TOKEN") token: String,
+    ): ResponseEntity<ApiResponse<TokenPositionQueueResponse>>
 }

--- a/src/main/kotlin/org/example/concertbackend/api/queue/WaitingQueueController.kt
+++ b/src/main/kotlin/org/example/concertbackend/api/queue/WaitingQueueController.kt
@@ -8,7 +8,6 @@ import org.example.concertbackend.common.model.ApiResponse
 import org.example.concertbackend.common.model.SuccessType
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
@@ -29,8 +28,7 @@ class WaitingQueueController(
             ),
         )
 
-    @GetMapping
-    fun findQueuePosition(
+    override fun findQueuePosition(
         @RequestHeader("QUEUE-AUTH-TOKEN") token: String,
     ): ResponseEntity<ApiResponse<TokenPositionQueueResponse>> =
         ResponseEntity
@@ -38,11 +36,7 @@ class WaitingQueueController(
             .body(
                 ApiResponse.success(
                     SuccessType.QUEUE_POSITION_FOUND,
-                    TokenPositionQueueResponse(
-                        token = token,
-                        status = "WAITING",
-                        waitingNumber = 1,
-                    ),
+                    waitingQueueUseCase.findQueuePosition(token),
                 ),
             )
 }

--- a/src/main/kotlin/org/example/concertbackend/api/queue/response/TokenPositionQueueResponse.kt
+++ b/src/main/kotlin/org/example/concertbackend/api/queue/response/TokenPositionQueueResponse.kt
@@ -1,7 +1,9 @@
 package org.example.concertbackend.api.queue.response
 
+import org.example.concertbackend.domain.queue.QueueStatus
+
 data class TokenPositionQueueResponse(
     val token: String,
-    val status: String,
+    val status: QueueStatus,
     val waitingNumber: Int,
 )

--- a/src/main/kotlin/org/example/concertbackend/application/queue/service/QueueTokenQueryService.kt
+++ b/src/main/kotlin/org/example/concertbackend/application/queue/service/QueueTokenQueryService.kt
@@ -1,5 +1,7 @@
 package org.example.concertbackend.application.queue.service
 
+import org.example.concertbackend.common.exception.BusinessException
+import org.example.concertbackend.common.model.ErrorType
 import org.example.concertbackend.domain.queue.QueueTokenRepository
 import org.springframework.stereotype.Service
 
@@ -7,5 +9,8 @@ import org.springframework.stereotype.Service
 class QueueTokenQueryService(
     private val queueTokenRepository: QueueTokenRepository,
 ) {
-    fun findByUserIdOrNull(userId: Long) = queueTokenRepository.findByUserIdOrNull(userId)
+    fun findByUserId(userId: Long) = queueTokenRepository.findByUserId(userId)
+
+    fun getByToken(token: String) =
+        queueTokenRepository.findByToken(token) ?: throw BusinessException(ErrorType.WAITING_QUEUE_TOKEN_NOT_FOUND)
 }

--- a/src/main/kotlin/org/example/concertbackend/application/queue/service/WaitingQueueQueryService.kt
+++ b/src/main/kotlin/org/example/concertbackend/application/queue/service/WaitingQueueQueryService.kt
@@ -1,0 +1,31 @@
+package org.example.concertbackend.application.queue.service
+
+import org.example.concertbackend.api.queue.response.TokenPositionQueueResponse
+import org.example.concertbackend.common.exception.BusinessException
+import org.example.concertbackend.common.model.ErrorType
+import org.example.concertbackend.domain.queue.QueueStatus
+import org.example.concertbackend.domain.queue.WaitingQueueManager
+import org.springframework.stereotype.Service
+
+@Service
+class WaitingQueueQueryService(
+    private val waitingQueueManager: WaitingQueueManager,
+) {
+    fun findQueuePosition(token: String): TokenPositionQueueResponse {
+        val waitingQueueInToken =
+            waitingQueueManager.findByToken(token)
+                ?: throw BusinessException(ErrorType.WAITING_QUEUE_TOKEN_NOT_FOUND)
+
+        val position =
+            when (waitingQueueInToken.status) {
+                QueueStatus.WAITING -> waitingQueueManager.findPosition(token)
+                else -> 0
+            }
+
+        return TokenPositionQueueResponse(
+            token = token,
+            status = waitingQueueInToken.status,
+            waitingNumber = position,
+        )
+    }
+}

--- a/src/main/kotlin/org/example/concertbackend/application/queue/usecase/WaitingQueueUseCase.kt
+++ b/src/main/kotlin/org/example/concertbackend/application/queue/usecase/WaitingQueueUseCase.kt
@@ -2,9 +2,11 @@ package org.example.concertbackend.application.queue.usecase
 
 import org.example.concertbackend.api.queue.request.RegisterQueueRequest
 import org.example.concertbackend.api.queue.response.RegisterQueueResponse
+import org.example.concertbackend.api.queue.response.TokenPositionQueueResponse
 import org.example.concertbackend.application.queue.service.QueueTokenCommandService
 import org.example.concertbackend.application.queue.service.QueueTokenQueryService
 import org.example.concertbackend.application.queue.service.WaitingQueueCommandService
+import org.example.concertbackend.application.queue.service.WaitingQueueQueryService
 import org.example.concertbackend.application.user.service.UserQueryService
 import org.springframework.stereotype.Component
 
@@ -14,15 +16,21 @@ class WaitingQueueUseCase(
     private val waitingQueueCommandService: WaitingQueueCommandService,
     private val queueTokenCommandService: QueueTokenCommandService,
     private val queueTokenQueryService: QueueTokenQueryService,
+    private val waitingQueueQueryService: WaitingQueueQueryService,
 ) {
     fun addToQueue(request: RegisterQueueRequest): RegisterQueueResponse {
         userQueryService.findById(request.userId)
         val waitingQueueInToken =
-            queueTokenQueryService.findByUserIdOrNull(request.userId)
+            queueTokenQueryService.findByUserId(request.userId)
                 ?: queueTokenCommandService
                     .create(request.userId)
                     .also { waitingQueueCommandService.addToQueue(it.token) }
 
         return RegisterQueueResponse(waitingQueueInToken.token)
+    }
+
+    fun findQueuePosition(token: String): TokenPositionQueueResponse {
+        queueTokenQueryService.getByToken(token)
+        return waitingQueueQueryService.findQueuePosition(token)
     }
 }

--- a/src/main/kotlin/org/example/concertbackend/domain/queue/QueueStatus.kt
+++ b/src/main/kotlin/org/example/concertbackend/domain/queue/QueueStatus.kt
@@ -2,6 +2,6 @@ package org.example.concertbackend.domain.queue
 
 enum class QueueStatus {
     WAITING,
-    IN_PROGRESS,
-    COMPLETED
+    ACTIVE,
+    EXPIRED
 }

--- a/src/main/kotlin/org/example/concertbackend/domain/queue/QueueTokenRepository.kt
+++ b/src/main/kotlin/org/example/concertbackend/domain/queue/QueueTokenRepository.kt
@@ -3,5 +3,7 @@ package org.example.concertbackend.domain.queue
 interface QueueTokenRepository {
     fun save(queueToken: QueueToken): QueueToken
 
-    fun findByUserIdOrNull(userId: Long): QueueToken?
+    fun findByUserId(userId: Long): QueueToken?
+
+    fun findByToken(token: String): QueueToken?
 }

--- a/src/main/kotlin/org/example/concertbackend/domain/queue/WaitingQueueManager.kt
+++ b/src/main/kotlin/org/example/concertbackend/domain/queue/WaitingQueueManager.kt
@@ -4,4 +4,6 @@ interface WaitingQueueManager {
     fun addToQueue(queue: WaitingQueue): WaitingQueue
 
     fun findPosition(queueToken: String): Int
+
+    fun findByToken(token: String): WaitingQueue?
 }

--- a/src/main/kotlin/org/example/concertbackend/infrastructure/persistence/queue/repository/DataJpaQueueTokenRepository.kt
+++ b/src/main/kotlin/org/example/concertbackend/infrastructure/persistence/queue/repository/DataJpaQueueTokenRepository.kt
@@ -5,4 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository
 
 interface DataJpaQueueTokenRepository : JpaRepository<QueueTokenJpaEntity, Long> {
     fun findByUserId(userId: Long): QueueTokenJpaEntity?
+
+    fun findByToken(token: String): QueueTokenJpaEntity?
 }

--- a/src/main/kotlin/org/example/concertbackend/infrastructure/persistence/queue/repository/DataJpaWaitingQueueRepository.kt
+++ b/src/main/kotlin/org/example/concertbackend/infrastructure/persistence/queue/repository/DataJpaWaitingQueueRepository.kt
@@ -15,4 +15,6 @@ interface DataJpaWaitingQueueRepository : JpaRepository<WaitingQueueJpaEntity, L
         """,
     )
     fun findAllByStatus(status: QueueStatus): List<WaitingQueueJpaEntity>
+
+    fun findByToken(token: String): WaitingQueueJpaEntity?
 }

--- a/src/main/kotlin/org/example/concertbackend/infrastructure/persistence/queue/repository/JpaQueueTokenRepository.kt
+++ b/src/main/kotlin/org/example/concertbackend/infrastructure/persistence/queue/repository/JpaQueueTokenRepository.kt
@@ -15,9 +15,14 @@ class JpaQueueTokenRepository(
             .save(queueToken.toJpaEntity())
             .toDomain()
 
-    override fun findByUserIdOrNull(userId: Long): QueueToken? {
-        return dataJpaQueueTokenRepository
+    override fun findByUserId(userId: Long): QueueToken? =
+        dataJpaQueueTokenRepository
             .findByUserId(userId)
+            ?.toDomain()
+
+    override fun findByToken(token: String): QueueToken? {
+        return dataJpaQueueTokenRepository
+            .findByToken(token)
             ?.toDomain()
     }
 }

--- a/src/main/kotlin/org/example/concertbackend/infrastructure/persistence/queue/repository/JpaWaitingQueueRepository.kt
+++ b/src/main/kotlin/org/example/concertbackend/infrastructure/persistence/queue/repository/JpaWaitingQueueRepository.kt
@@ -25,4 +25,10 @@ class JpaWaitingQueueRepository(
             .takeIf { it >= 0 }
             ?.inc()
             ?: throw BusinessException(ErrorType.WAITING_QUEUE_TOKEN_NOT_FOUND)
+
+    override fun findByToken(token: String): WaitingQueue? {
+        return dataJpaWaitingQueueRepository
+            .findByToken(token)
+            ?.toDomain()
+    }
 }

--- a/src/test/kotlin/org/example/concertbackend/application/queue/service/QueueTokenQueryServiceTest.kt
+++ b/src/test/kotlin/org/example/concertbackend/application/queue/service/QueueTokenQueryServiceTest.kt
@@ -1,0 +1,39 @@
+package org.example.concertbackend.application.queue.service
+
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.example.concertbackend.common.exception.BusinessException
+import org.example.concertbackend.common.model.ErrorType
+import org.example.concertbackend.domain.queue.QueueTokenRepository
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(MockKExtension::class)
+class QueueTokenQueryServiceTest {
+    @InjectMockKs
+    private lateinit var queueTokenQueryService: QueueTokenQueryService
+
+    @MockK
+    private lateinit var queueTokenRepository: QueueTokenRepository
+
+    @Nested
+    @DisplayName("토큰을 통해 대기열 토큰 조회")
+    inner class GetByToken {
+        @Test
+        @DisplayName("토큰이 존재하지 않는 경우 예외를 던진다.")
+        fun notExistsToken() {
+            val invalidToken = "invalidToken"
+
+            every { queueTokenRepository.findByToken(invalidToken) } returns null
+
+            assertThatThrownBy { queueTokenQueryService.getByToken(invalidToken) }
+                .isInstanceOf(BusinessException::class.java)
+                .hasMessage(ErrorType.WAITING_QUEUE_TOKEN_NOT_FOUND.message)
+        }
+    }
+}

--- a/src/test/kotlin/org/example/concertbackend/application/queue/service/WaitingQueueQueryServiceTest.kt
+++ b/src/test/kotlin/org/example/concertbackend/application/queue/service/WaitingQueueQueryServiceTest.kt
@@ -1,0 +1,70 @@
+package org.example.concertbackend.application.queue.service
+
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.example.concertbackend.api.queue.response.TokenPositionQueueResponse
+import org.example.concertbackend.common.exception.BusinessException
+import org.example.concertbackend.common.model.ErrorType
+import org.example.concertbackend.domain.queue.QueueStatus
+import org.example.concertbackend.domain.queue.WaitingQueue
+import org.example.concertbackend.domain.queue.WaitingQueueManager
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.extension.ExtendWith
+import kotlin.test.Test
+
+@ExtendWith(MockKExtension::class)
+class WaitingQueueQueryServiceTest {
+    @InjectMockKs
+    private lateinit var waitingQueueQueryService: WaitingQueueQueryService
+
+    @MockK
+    private lateinit var waitingQueueManager: WaitingQueueManager
+
+    @Nested
+    @DisplayName("대기열에서 현재 위치 조회")
+    inner class FindQueuePosition {
+        private val token = "token"
+
+        @Test
+        @DisplayName("전달한 토큰이 존재하지 않는 경우 예외를 던진다.")
+        fun notExistsToken() {
+            every { waitingQueueManager.findByToken(token) } returns null
+
+            assertThatThrownBy { waitingQueueQueryService.findQueuePosition(token) }
+                .isInstanceOf(BusinessException::class.java)
+                .hasMessage(ErrorType.WAITING_QUEUE_TOKEN_NOT_FOUND.message)
+        }
+
+        @Test
+        @DisplayName("전달한 토큰이 대기 상태가 아니라면 대기번호 0을 반환한다.")
+        fun notWaitingStatus() {
+            val waitingQueueInToken = WaitingQueue(token, QueueStatus.ACTIVE)
+            val want = TokenPositionQueueResponse(token, QueueStatus.ACTIVE, 0)
+            every { waitingQueueManager.findByToken(token) } returns waitingQueueInToken
+
+            val got = waitingQueueQueryService.findQueuePosition(token)
+
+            assertThat(got).isEqualTo(want)
+        }
+
+        @Test
+        @DisplayName("전달한 토큰이 대기 상태라면 대기번호를 반환한다.")
+        fun waitingStatus() {
+            val waitingQueueInToken = WaitingQueue(token)
+            val position = 1
+            val want = TokenPositionQueueResponse(token, QueueStatus.WAITING, position)
+
+            every { waitingQueueManager.findByToken(token) } returns waitingQueueInToken
+            every { waitingQueueManager.findPosition(token) } returns position
+
+            val got = waitingQueueQueryService.findQueuePosition(token)
+
+            assertThat(got).isEqualTo(want)
+        }
+    }
+}

--- a/src/test/kotlin/org/example/concertbackend/application/queue/usecase/WaitingQueueUseCaseTest.kt
+++ b/src/test/kotlin/org/example/concertbackend/application/queue/usecase/WaitingQueueUseCaseTest.kt
@@ -10,6 +10,7 @@ import org.example.concertbackend.api.queue.response.RegisterQueueResponse
 import org.example.concertbackend.application.queue.service.QueueTokenCommandService
 import org.example.concertbackend.application.queue.service.QueueTokenQueryService
 import org.example.concertbackend.application.queue.service.WaitingQueueCommandService
+import org.example.concertbackend.application.queue.service.WaitingQueueQueryService
 import org.example.concertbackend.application.user.service.UserQueryService
 import org.example.concertbackend.domain.queue.QueueToken
 import org.example.concertbackend.domain.queue.WaitingQueue
@@ -36,6 +37,9 @@ class WaitingQueueUseCaseTest {
     @MockK
     private lateinit var queueTokenQueryService: QueueTokenQueryService
 
+    @MockK
+    private lateinit var waitingQueueQueryService: WaitingQueueQueryService
+
     @Nested
     @DisplayName("대기열 큐 등록")
     inner class AddToQueue {
@@ -49,7 +53,7 @@ class WaitingQueueUseCaseTest {
         @DisplayName("대기열에 이미 등록된 유저인 경우 대기열에 등록하지 않고 등록된 토큰을 반환한다.")
         fun addToQueueWhenQueueTokenExists() {
             every { userQueryService.findById(request.userId) } returns user
-            every { queueTokenQueryService.findByUserIdOrNull(request.userId) } returns waitingQueueInToken
+            every { queueTokenQueryService.findByUserId(request.userId) } returns waitingQueueInToken
 
             val got = waitingQueueUseCase.addToQueue(request)
 
@@ -61,7 +65,7 @@ class WaitingQueueUseCaseTest {
         fun addToQueueWhenQueueTokenNotExists() {
             val registerToken = WaitingQueue(token)
             every { userQueryService.findById(request.userId) } returns user
-            every { queueTokenQueryService.findByUserIdOrNull(request.userId) } returns null
+            every { queueTokenQueryService.findByUserId(request.userId) } returns null
             every { queueTokenCommandService.create(request.userId) } returns waitingQueueInToken
             every { waitingQueueCommandService.addToQueue(token) } returns registerToken
 


### PR DESCRIPTION
## 내용
- 대기열 토큰의 현재 위치를 조회하는 API 구현
- WAITING 상태가 아니라면 대기열 번호는 0번 반환, WAITING 상태의 데이터를 확인하여 현재 위치 반환
- 대기열 토큰 조회에 대한 스웨거 추가
- 대기열 위치 조회에 대한 단위 테스트 추가